### PR TITLE
Dockerize and set up deploy workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,7 @@
 **/.dockerignore
 **/.env
 **/.git
+**/.github
 **/.gitignore
 .idea
 5m5v-config.yaml*
@@ -15,4 +16,5 @@ Dockerfile
 LICENSE
 node_modules
 README.md
+test
 yarn-error.log

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+# Include any files or directories that you don't want to be copied to your
+# container here (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/go/build-context-dockerignore/
+
+**/.dockerignore
+**/.env
+**/.git
+**/.gitignore
+.idea
+5m5v-config.yaml*
+compose.yaml
+Dockerfile
+LICENSE
+node_modules
+README.md
+yarn-error.log

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,6 +9,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  SERVICE_NAME: 5m5v-bot
   DEPLOY_HOST: 206.189.96.198
   DEPLOY_USER: deploy
 
@@ -45,36 +46,18 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Log stuff (temporary)
+      - name: Deploy bot to Docker droplet
         run: |
-          echo "${{ env.REGISTRY }}"
-          echo "${{ env.IMAGE_NAME }}"
-          echo "${{ steps.meta.outputs.tags }}"
-          echo "${{ steps.meta.outputs.labels }}"
-#
-#      - name: Deploy Metabase to docker droplet
-#        run: >
-#          eval `ssh-agent -s` &&
-#          ssh-add - <<< "${{ secrets.DEPLOY_PRIVATE_KEY }}" &&
-#          ssh -o StrictHostKeyChecking=no ${DEPLOY_USER}@${DEPLOY_HOST} -C
-#          "
-#          docker pull ${{ env.REGISTRY }}/${{ steps.meta.outputs.tags }} &&
-#          (docker stop ${SERVICE_NAME} && docker rm ${SERVICE_NAME} || true) &&
-#          docker run -d \
-#            -v \${HOME}/${SERVICE_NAME}:/metabase-data \
-#            -e 'MB_DB_FILE=/metabase-data/metabase.db' \
-#            --restart always \
-#            --label traefik.enable=true \
-#            --label traefik.http.middlewares.https-redirect.redirectscheme.scheme=https \
-#            --label traefik.http.middlewares.https-redirect.redirectscheme.permanent=true \
-#            --label traefik.http.routers.metabase-http.middlewares=https-redirect \
-#            --label traefik.http.routers.metabase-http.rule=Host\(\\\`metabase.veganhacktivists.org\\\`\) \
-#            --label traefik.http.routers.metabase-http.entrypoints=http \
-#            --label traefik.http.routers.metabase-https.rule=Host\(\\\`metabase.veganhacktivists.org\\\`\) \
-#            --label traefik.http.routers.metabase-https.tls.certresolver=le \
-#            --label traefik.http.routers.metabase-https.tls=true \
-#            --label traefik.http.routers.metabase-https.entrypoints=https \
-#            --network=traefik-public \
-#            --name ${SERVICE_NAME} \
-#            metabase/metabase:${METABASE_TAG}
-#          "
+          eval `ssh-agent -s`
+          ssh-add - <<< "${{ secrets.DEPLOY_PRIVATE_KEY }}"
+          ssh -o StrictHostKeyChecking=no ${DEPLOY_USER}@${DEPLOY_HOST} -C
+          "
+          echo "${{ secrets.BOT_CONFIG }}" > \${HOME}/${SERVICE_NAME}/5m5v-config.yaml
+          docker pull ${{ steps.meta.outputs.tags }} &&
+          docker rm -f ${SERVICE_NAME} &&
+          docker run -d \
+            -v \${HOME}/${SERVICE_NAME}/5m5v-config.yaml:/usr/src/app/5m5v-config.yaml \
+            --restart always \
+            --name ${SERVICE_NAME} \
+            ${{ steps.meta.outputs.tags }}
+          "

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,13 +6,14 @@ on:
       - dockerize-and-deploy # FIXME: temporary
   workflow_dispatch:
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
 
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,7 +3,7 @@ name: Deploy
 on:
   push:
     branches:
-      - dockerize-and-deploy # FIXME: temporary
+      - master
   workflow_dispatch:
 
 env:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -54,6 +54,7 @@ jobs:
           "
           mkdir -p \${HOME}/${SERVICE_NAME} &&
           echo \"${{ secrets.BOT_CONFIG }}\" > \${HOME}/${SERVICE_NAME}/5m5v-config.yaml &&
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin &&
           docker pull ${{ steps.meta.outputs.tags }} &&
           docker rm -f ${SERVICE_NAME} &&
           docker run -d \

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -52,7 +52,8 @@ jobs:
           ssh-add - <<< "${{ secrets.DEPLOY_PRIVATE_KEY }}" &&
           ssh -o StrictHostKeyChecking=no ${DEPLOY_USER}@${DEPLOY_HOST} -C
           "
-          echo \"${{ secrets.BOT_CONFIG }}\" > \${HOME}/${SERVICE_NAME}/5m5v-config.yaml
+          mkdir -p \${HOME}/${SERVICE_NAME} &&
+          echo \"${{ secrets.BOT_CONFIG }}\" > \${HOME}/${SERVICE_NAME}/5m5v-config.yaml &&
           docker pull ${{ steps.meta.outputs.tags }} &&
           docker rm -f ${SERVICE_NAME} &&
           docker run -d \

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,6 +9,8 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  DEPLOY_HOST: 206.189.96.198
+  DEPLOY_USER: deploy
 
 jobs:
   deploy:
@@ -42,3 +44,37 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Log stuff (temporary)
+        run: |
+          echo "${{ env.REGISTRY }}"
+          echo "${{ env.IMAGE_NAME }}"
+          echo "${{ steps.meta.outputs.tags }}"
+          echo "${{ steps.meta.outputs.labels }}"
+#
+#      - name: Deploy Metabase to docker droplet
+#        run: >
+#          eval `ssh-agent -s` &&
+#          ssh-add - <<< "${{ secrets.DEPLOY_PRIVATE_KEY }}" &&
+#          ssh -o StrictHostKeyChecking=no ${DEPLOY_USER}@${DEPLOY_HOST} -C
+#          "
+#          docker pull ${{ env.REGISTRY }}/${{ steps.meta.outputs.tags }} &&
+#          (docker stop ${SERVICE_NAME} && docker rm ${SERVICE_NAME} || true) &&
+#          docker run -d \
+#            -v \${HOME}/${SERVICE_NAME}:/metabase-data \
+#            -e 'MB_DB_FILE=/metabase-data/metabase.db' \
+#            --restart always \
+#            --label traefik.enable=true \
+#            --label traefik.http.middlewares.https-redirect.redirectscheme.scheme=https \
+#            --label traefik.http.middlewares.https-redirect.redirectscheme.permanent=true \
+#            --label traefik.http.routers.metabase-http.middlewares=https-redirect \
+#            --label traefik.http.routers.metabase-http.rule=Host\(\\\`metabase.veganhacktivists.org\\\`\) \
+#            --label traefik.http.routers.metabase-http.entrypoints=http \
+#            --label traefik.http.routers.metabase-https.rule=Host\(\\\`metabase.veganhacktivists.org\\\`\) \
+#            --label traefik.http.routers.metabase-https.tls.certresolver=le \
+#            --label traefik.http.routers.metabase-https.tls=true \
+#            --label traefik.http.routers.metabase-https.entrypoints=https \
+#            --network=traefik-public \
+#            --name ${SERVICE_NAME} \
+#            metabase/metabase:${METABASE_TAG}
+#          "

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,43 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - dockerize-and-deploy # FIXME: temporary
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -47,12 +47,12 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Deploy bot to Docker droplet
-        run: |
-          eval `ssh-agent -s`
-          ssh-add - <<< "${{ secrets.DEPLOY_PRIVATE_KEY }}"
+        run: >
+          eval `ssh-agent -s` &&
+          ssh-add - <<< "${{ secrets.DEPLOY_PRIVATE_KEY }}" &&
           ssh -o StrictHostKeyChecking=no ${DEPLOY_USER}@${DEPLOY_HOST} -C
           "
-          echo "${{ secrets.BOT_CONFIG }}" > \${HOME}/${SERVICE_NAME}/5m5v-config.yaml
+          echo \"${{ secrets.BOT_CONFIG }}\" > \${HOME}/${SERVICE_NAME}/5m5v-config.yaml
           docker pull ${{ steps.meta.outputs.tags }} &&
           docker rm -f ${SERVICE_NAME} &&
           docker run -d \

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -47,9 +47,9 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Deploy bot to Docker droplet
-        run: >
-          eval `ssh-agent -s` &&
-          ssh-add - <<< "${{ secrets.DEPLOY_PRIVATE_KEY }}" &&
+        run: |
+          eval `ssh-agent -s`
+          ssh-add - <<< "${{ secrets.DEPLOY_PRIVATE_KEY }}"
           ssh -o StrictHostKeyChecking=no ${DEPLOY_USER}@${DEPLOY_HOST} -C
           "
           mkdir -p \${HOME}/${SERVICE_NAME} &&

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -12,6 +12,7 @@ env:
   SERVICE_NAME: 5m5v-bot
   DEPLOY_HOST: 206.189.96.198
   DEPLOY_USER: deploy
+  CONFIG_FILE: 5m5v-config.yaml
 
 jobs:
   deploy:
@@ -53,12 +54,12 @@ jobs:
           ssh -o StrictHostKeyChecking=no ${DEPLOY_USER}@${DEPLOY_HOST} -C
           "
           mkdir -p \${HOME}/${SERVICE_NAME} &&
-          echo \"${{ secrets.BOT_CONFIG }}\" > \${HOME}/${SERVICE_NAME}/5m5v-config.yaml &&
+          echo \"${{ secrets.BOT_CONFIG }}\" > \${HOME}/${SERVICE_NAME}/${CONFIG_FILE} &&
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin &&
           docker pull ${{ steps.meta.outputs.tags }} &&
           docker rm -f ${SERVICE_NAME} &&
           docker run -d \
-            -v \${HOME}/${SERVICE_NAME}/5m5v-config.yaml:/usr/src/app/5m5v-config.yaml \
+            -v \${HOME}/${SERVICE_NAME}/${CONFIG_FILE}:/usr/src/app/${CONFIG_FILE} \
             --restart always \
             --name ${SERVICE_NAME} \
             ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -47,9 +47,9 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Deploy bot to Docker droplet
-        run: |
-          eval `ssh-agent -s`
-          ssh-add - <<< "${{ secrets.DEPLOY_PRIVATE_KEY }}"
+        run: >
+          eval `ssh-agent -s` &&
+          ssh-add - <<< "${{ secrets.DEPLOY_PRIVATE_KEY }}" &&
           ssh -o StrictHostKeyChecking=no ${DEPLOY_USER}@${DEPLOY_HOST} -C
           "
           mkdir -p \${HOME}/${SERVICE_NAME} &&

--- a/5m5v-bot.js
+++ b/5m5v-bot.js
@@ -16,7 +16,7 @@ try {
 const languages = config.users.map(user => user.language);
 const pollingIntervalMs = 40 * 1000;
 const retweetDelayMs = config.delaytime || 2 * 60 * 1000;
-const isDryRun = true; //process.argv[2] === '--dry-run';
+const isDryRun = process.argv[2] === '--dry-run';
 
 const tweetFilter = new TweetFilter(config.exclude, languages);
 const rettiwt = new Rettiwt({ apiKey: config.users[0].api_key });

--- a/5m5v-bot.js
+++ b/5m5v-bot.js
@@ -13,6 +13,8 @@ try {
   throw `Unable to load config file: ${error.message}`;
 }
 
+process.exit();
+
 const languages = config.users.map(user => user.language);
 const pollingIntervalMs = 40 * 1000;
 const retweetDelayMs = config.delaytime || 2 * 60 * 1000;

--- a/5m5v-bot.js
+++ b/5m5v-bot.js
@@ -13,12 +13,10 @@ try {
   throw `Unable to load config file: ${error.message}`;
 }
 
-process.exit();
-
 const languages = config.users.map(user => user.language);
 const pollingIntervalMs = 40 * 1000;
 const retweetDelayMs = config.delaytime || 2 * 60 * 1000;
-const isDryRun = process.argv[2] === '--dry-run';
+const isDryRun = true; //process.argv[2] === '--dry-run';
 
 const tweetFilter = new TweetFilter(config.exclude, languages);
 const rettiwt = new Rettiwt({ apiKey: config.users[0].api_key });

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1
+
+ARG NODE_VERSION=20.11.1
+
+FROM node:${NODE_VERSION}-alpine
+
+ENV NODE_ENV production
+
+WORKDIR /usr/src/app
+
+RUN --mount=type=bind,source=package.json,target=package.json \
+    --mount=type=bind,source=yarn.lock,target=yarn.lock \
+    --mount=type=cache,target=/root/.yarn \
+    yarn install --production --frozen-lockfile
+
+USER node
+
+COPY . .
+
+CMD node .

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,6 @@
+services:
+  bot:
+    build:
+      context: .
+    volumes:
+        - '.:/usr/src/app'

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,3 +4,4 @@ services:
       context: .
     volumes:
         - '.:/usr/src/app'
+    container_name: bot


### PR DESCRIPTION
This dockerizes the bot and sets up a GitHub workflow which does the following:

1. Builds the Docker image
2. Pushes it to the GitHub Container Registry (ghcr.io)
3. Connects to our Docker droplet (DO) via SSH
4. Create/update the bot's config file
5. Pull the Docker image
6. Stop and remove any active bot container
7. Spin up a container from that image while bind-mounting the bot's config file