### PR TITLE
Handle login + auto re-login when bot account gets logged out

### DIFF
--- a/5m5v-bot.js
+++ b/5m5v-bot.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs');
 const yaml = require('js-yaml');
-const { Rettiwt } = require('@jeto314/rettiwt-api');
+const { Rettiwt } = require('rettiwt-api');
 const TweetFilter = require('./lib/filter');
 const util = require('./lib/util');
 

--- a/5m5v-bot.js
+++ b/5m5v-bot.js
@@ -51,6 +51,8 @@ async function getApiKey(user) {
               const rettiwt = new Rettiwt({ apiKey: await getApiKey(user) });
 
               await rettiwt.tweet.retweet(tweet.id);
+
+              console.log(`Retweeted tweet ${tweet.id} in ${language}:\n${tweet.fullText}`);
             } catch (error) {
               console.error(`Unable to retweet ${tweet.id} in ${language}: ${error.message}`);
 
@@ -59,8 +61,6 @@ async function getApiKey(user) {
               }
             }
           }
-
-          console.log(`Retweeted tweet ${tweet.id} in ${language}:\n${tweet.fullText}`);
         }
       }
     } catch (error) {

--- a/5m5v-bot.js
+++ b/5m5v-bot.js
@@ -25,7 +25,7 @@ async function getApiKey(user) {
 
     user.apiKey = await new Rettiwt().auth.login(user.email, user.username, user.password);
 
-    console.log(`Logged in as ${user.username} with API key ${user.apiKey}`);
+    console.log(`Logged in!`);
   }
 
   return user.apiKey;

--- a/5m5v-bot.js
+++ b/5m5v-bot.js
@@ -44,21 +44,21 @@ async function getApiKey(user) {
         for (const language of matchingLanguages) {
           await new Promise(resolve => setTimeout(resolve, retweetDelayMs));
 
-          if (!isDryRun) {
-            const user = config.users.find(user => user.language === language);
+          const user = config.users.find(user => user.language === language);
 
-            try {
+          try {
+            if (!isDryRun) {
               const rettiwt = new Rettiwt({ apiKey: await getApiKey(user) });
 
               await rettiwt.tweet.retweet(tweet.id);
+            }
 
-              console.log(`Retweeted tweet ${tweet.id} in ${language}:\n${tweet.fullText}`);
-            } catch (error) {
-              console.error(`Unable to retweet ${tweet.id} in ${language}: ${error.message}`);
+            console.log(`Retweeted tweet ${tweet.id} in ${language}:\n${tweet.fullText}`);
+          } catch (error) {
+            console.error(`Unable to retweet ${tweet.id} in ${language}: ${error.message}`);
 
-              if (error.constructor.name === 'RettiwtError' && error.code === 32) {
-                user.apiKey = null;
-              }
+            if (error.constructor.name === 'RettiwtError' && error.code === 32) {
+              user.apiKey = null;
             }
           }
         }

--- a/5m5v-bot.js
+++ b/5m5v-bot.js
@@ -13,7 +13,7 @@ try {
   throw `Unable to load config file: ${error.message}`;
 }
 
-if (!('users' in (config ?? [])) || config.users.length === 0) {
+if ((config?.users || []).length === 0) {
   throw 'No users defined in config file';
 }
 

--- a/5m5v-bot.js
+++ b/5m5v-bot.js
@@ -25,7 +25,7 @@ async function getApiKey(user) {
 
     user.apiKey = await new Rettiwt().auth.login(user.email, user.username, user.password);
 
-    console.log(`Logged in!`);
+    console.log('Logged in!');
   }
 
   return user.apiKey;

--- a/5m5v-bot.js
+++ b/5m5v-bot.js
@@ -13,6 +13,14 @@ try {
   throw `Unable to load config file: ${error.message}`;
 }
 
+if (!('users' in (config ?? [])) || config.users.length === 0) {
+  throw 'No users defined in config file';
+}
+
+if (!config.users.every(user => ['language', 'email', 'username', 'password'].every(key => key in (user ?? [])))) {
+  throw 'At least one user is missing required fields in config file';
+}
+
 const languages = config.users.map(user => user.language);
 const pollingIntervalMs = 40 * 1000;
 const retweetDelayMs = config.delaytime || 2 * 60 * 1000;

--- a/5m5v-config.yaml.example
+++ b/5m5v-config.yaml.example
@@ -1,3 +1,5 @@
 users:
-  - api_key: Aa0Aa0Aa0Aa0Aa0Aa0Aa0Aa0Aa0Aa0Aa0Aa0Aa0Aa0Aa0
-    language: english
+  - language: 'english'
+    username: 'user1'
+    email: 'user1@domain.com'
+    password: 'password123#@!'

--- a/README.md
+++ b/README.md
@@ -28,10 +28,14 @@ The configuration is loaded from `5m5v-config.yaml` in the working directory, wh
 
 #### `users`
 A list containing all users to retweet with. The first user listed will be used to search tweets with.
-#### `users.api_key`
-To obtain the API key for a given Twitter user, follow the [instructions from the Rettiwt-API package](https://github.com/Rishikant181/Rettiwt-API#authentication).
 #### `users.language`
 The language that this user will be retweeting matches from.
+#### `users.username`
+The Twitter username of that user (without the @).
+#### `users.email`
+The email address of the Twitter account.
+#### `users.password`
+The password of the Twitter account.
 #### `exclude` *(optional)*
 A list of keywords that if found in a Tweet will exclude that Tweet from being retweeted.
 #### `delaytime` *(optional)*

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "5m5v-bot.js",
   "dependencies": {
     "js-yaml": "^3.13.1",
-    "@jeto314/rettiwt-api": "1.0.0"
+    "rettiwt-api": "2.7.1"
   },
   "devDependencies": {
     "nodeunit": "^0.11.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -105,18 +105,6 @@
     "@babel/helper-validator-identifier" "^7.22.20"
     to-fast-properties "^2.0.0"
 
-"@jeto314/rettiwt-api@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@jeto314/rettiwt-api/-/rettiwt-api-1.0.0.tgz#bff3544713df4a5f1e4190ee7c8545ff80b81791"
-  integrity sha512-8efcjpB+wBXdOrWcBdz/m58LTYC8JQ5PQqPMGEoQ1z2CGNmr6YUP/+as8cauPHd131CdtIROzOtwhkg46mytNQ==
-  dependencies:
-    axios "1.6.3"
-    class-validator "0.14.1"
-    commander "11.1.0"
-    https-proxy-agent "7.0.2"
-    rettiwt-auth "2.1.0"
-    rettiwt-core "3.4.0-alpha.2"
-
 "@jridgewell/gen-mapping@^0.3.2":
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz#7e02e6eb5df901aaedb08514203b096614024098"
@@ -1318,6 +1306,18 @@ resolve@^1.10.0:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
+rettiwt-api@2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rettiwt-api/-/rettiwt-api-2.7.1.tgz#8721606d08222d7034652782f7a09be53d28ad49"
+  integrity sha512-Q0757mFJTY70jFCFjLjzy1Dz/DIPR+HhnQaFBxz9HUZ4Dp9CStC/4OvEq6I3P8UlXTA3HVexTlevxRp9PHrnqw==
+  dependencies:
+    axios "1.6.3"
+    class-validator "0.14.1"
+    commander "11.1.0"
+    https-proxy-agent "7.0.2"
+    rettiwt-auth "2.1.0"
+    rettiwt-core "3.4.0"
+
 rettiwt-auth@2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/rettiwt-auth/-/rettiwt-auth-2.1.0.tgz#43fedd40cab5b775b92a1bef740d7b2a36553463"
@@ -1328,10 +1328,10 @@ rettiwt-auth@2.1.0:
     cookiejar "2.1.4"
     https-proxy-agent "7.0.2"
 
-rettiwt-core@3.4.0-alpha.2:
-  version "3.4.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/rettiwt-core/-/rettiwt-core-3.4.0-alpha.2.tgz#d3033d0db7a05f503e3b0aef5981d33897f0d08b"
-  integrity sha512-775cDTPWZXhY+znEOsjupIgj/Mmi8shKhLveShm1KnXEX1Qc5SjTEnpQv1dHmDaxiV9n6BIQ73E7K9AucBl+Mg==
+rettiwt-core@3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/rettiwt-core/-/rettiwt-core-3.4.0.tgz#515aa168a5a64effa6cb2340debafebf5d4ee8a1"
+  integrity sha512-7N2wV+AB5fJVMzyE0s6FS9jZ/4z/eXIM1DlhOqeWous36PZSDPprINIcdPM8LVmfMEpq4aanplHkqCheNGLXBw==
   dependencies:
     axios "1.6.3"
     class-validator "0.14.1"


### PR DESCRIPTION
Twitter API keys are supposed to be valid for a very long time, but for some reason they get invalidated very often (and a bit randomly). This PR addresses this issue by manually handling login and by detecting when the API key was invalidated in order to log back in again.