### PR TITLE
Handle login errors + add login delay

### DIFF
--- a/5m5v-bot.js
+++ b/5m5v-bot.js
@@ -23,6 +23,7 @@ if (!config.users.every(user => ['language', 'email', 'username', 'password'].ev
 
 const languages = config.users.map(user => user.language);
 const pollingIntervalMs = 40 * 1000;
+const loginDelayMs = 5 * 60 * 1000;
 const retweetDelayMs = config.delaytime || 2 * 60 * 1000;
 const isDryRun = process.argv[2] === '--dry-run';
 const tweetFilter = new TweetFilter(config.exclude, languages);
@@ -30,6 +31,8 @@ const tweetFilter = new TweetFilter(config.exclude, languages);
 async function getApiKey(user) {
   if (!user.apiKey) {
     console.log(`Logging in as ${user.username}...`);
+
+    await new Promise(resolve => setTimeout(resolve, loginDelayMs));
 
     user.apiKey = await new Rettiwt().auth.login(user.email, user.username, user.password);
 

--- a/5m5v-bot.js
+++ b/5m5v-bot.js
@@ -41,6 +41,8 @@ async function getApiKey(user, { retry = true } = {}) {
 
       user.apiKey = await new Rettiwt().auth.login(user.email, user.username, user.password);
 
+      console.log('Logged in!');
+
       return user.apiKey;
     } catch (e) {
       console.error(`Unable to log in: ${e.message}`);


### PR DESCRIPTION
This adds a bit of delay before logging in. Previously if the login failed, the container would restart automatically and try to immediately log in again, which can lock our account.

This also retries logging in on failure.